### PR TITLE
Code cleanup and Fixes

### DIFF
--- a/src/xdp/bpf_helpers.hh
+++ b/src/xdp/bpf_helpers.hh
@@ -21,7 +21,7 @@ static void *(*bpf_map_lookup_elem)(void *map, const void * key) = reinterpret_c
 
 static long (*bpf_xdp_adjust_head)(struct xdp_md *xdp_md, int delta) = reinterpret_cast<long(*)(struct xdp_md*, int)>(BPF_FUNC_xdp_adjust_head);
 
-static long (*bpf_perf_event_output)(void *ctx, void *map, __u64 flags, void *data, __u64 size) = reinterpret_cast<long(*)(void *, void *, __u64, void *, __u64)>(BPF_FUNC_xdp_adjust_head);
+static long (*bpf_perf_event_output)(void *ctx, void *map, __u64 flags, void *data, __u64 size) = reinterpret_cast<long(*)(void *, void *, __u64, void *, __u64)>(BPF_FUNC_perf_event_output);
 
 /*
 template<class Key, class T,
@@ -173,3 +173,24 @@ private:
 	int offset;
 };
 
+constexpr static inline __u16 csum16_add(__u16 csum, __u16 addend) {
+	__u16 res = csum;
+	res += addend;
+	return (res + (res < addend));
+}
+constexpr static inline __u16 csum16_sub(__u16 csum, __u16 addend) {
+	return csum16_add(csum, ~addend);
+}
+constexpr static inline __u16 csum_replace2(__u16 csum, __u16 old, __u16 next) {
+	return (~csum16_add(csum16_sub(~csum, old), next));
+}
+
+template<typename T>
+constexpr static inline
+T abs(const T a, const T b)
+{
+	if (a > b)
+		return a - b;
+	else
+		return b - a;
+}

--- a/src/xdp/bpf_helpers.hh
+++ b/src/xdp/bpf_helpers.hh
@@ -4,19 +4,6 @@
 #include <linux/bpf.h>
 #include <bpf/bpf_endian.h>
 
-
-#ifndef memset
-# define memset(dest, chr, n)   __builtin_memset((dest), (chr), (n))
-#endif
-
-#ifndef memcpy
-# define memcpy(dest, src, n)   __builtin_memcpy((dest), (src), (n))
-#endif
-
-#ifndef memmove
-# define memmove(dest, src, n)  __builtin_memmove((dest), (src), (n))
-#endif
-
 static void *(*bpf_map_lookup_elem)(void *map, const void * key) = reinterpret_cast<void*(*)(void*,const void*)>(BPF_FUNC_map_lookup_elem);
 
 static long (*bpf_xdp_adjust_head)(struct xdp_md *xdp_md, int delta) = reinterpret_cast<long(*)(struct xdp_md*, int)>(BPF_FUNC_xdp_adjust_head);
@@ -47,13 +34,6 @@ auto lookup(Map *map, const decltype(map->key) key)
 {
 	return (decltype(map->value)) bpf_map_lookup_elem(map, key);
 }
-
-
-#define SEC(name) \
-	_Pragma("GCC diagnostic push")						\
-	_Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")		\
-	__attribute__((section(name), used))					\
-	_Pragma("GCC diagnostic pop")						\
 
 template<class T>
 struct header

--- a/src/xdp/int-sink2.bpf.cc
+++ b/src/xdp/int-sink2.bpf.cc
@@ -13,14 +13,14 @@ struct map_a {
 	__uint(max_entries, 2);
 	__type(key, __u32);
 	__type(value, struct counter_set);
-} counters_map SEC(".maps");
+} counters_map [[gnu::section(".maps")]];
 
 struct map_b {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 64);
 	__type(key, __u32);
 	__type(value, __u32);
-} int_dscp_map SEC(".maps");
+} int_dscp_map [[gnu::section(".maps")]];
 
 struct headers {
 	header<struct ethhdr> ethernet;
@@ -35,7 +35,7 @@ struct headers {
 static inline bool export_int_metadata(Parser &parser, struct headers &hdr);
 
 extern "C"
-SEC("xdp")
+[[gnu::section("xdp")]]
 int ebpf_filter(struct xdp_md *ctx) {
 	Parser parser = {ctx};
 	struct headers hdr = {};
@@ -164,27 +164,27 @@ struct map_c {
 	__uint(max_entries, 512);
 	__type(key, struct flow_key);
 	__type(value, struct counter_set);
-} flow_counters_map SEC(".maps");
+} flow_counters_map [[gnu::section(".maps")]];
 
 struct map_d{
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 512);
 	__type(key, struct flow_key);
 	__type(value, struct flow_thresholds);
-} flow_thresholds_map SEC(".maps");
+} flow_thresholds_map [[gnu::section(".maps")]];
 
 struct map_e {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, 512);
 	__type(key, struct hop_key);
 	__type(value, struct hop_thresholds);
-} hop_thresholds_map SEC(".maps");
+} hop_thresholds_map [[gnu::section(".maps")]];
 
 struct map_f{
 	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
 	__uint(key_size, sizeof(__u32));
 	__uint(value_size, sizeof(__u32));
-} perf_output_map SEC(".maps");
+} perf_output_map [[gnu::section(".maps")]];
 
 
 #define MAX_HOPS 20
@@ -254,7 +254,7 @@ parse_metadata: {
 				__sync_fetch_and_add(&(counter_set_ptr->packets), 1);
 				__sync_fetch_and_add(&(counter_set_ptr->bytes), packetSize);
 			}
-			auto hop_threshold_ptr = (decltype(hop_thresholds_map.value))bpf_map_lookup_elem(&hop_thresholds_map, &accumulator.hop_key);
+			auto hop_threshold_ptr = lookup(&hop_thresholds_map, &accumulator.hop_key);
 			if (hop_threshold_ptr == nullptr) { goto export_meta; }
 			if (within_threshold(*hop_threshold_ptr, *hop_metadata_ptr) == false) { goto export_meta; }
 			accumulator.latency += bpf_ntohl(hop_metadata_ptr->egress_time) - bpf_ntohl(hop_metadata_ptr->ingress_time);


### PR DESCRIPTION
Fixed an issue with perf output, where the helper definition was pointing to the wrong helper ID. Additionally cleaned up the code to make it more consistent.